### PR TITLE
Allow BSV_TOOLS environment variable to overwrite BSVTools location

### DIFF
--- a/bsvNew.py
+++ b/bsvNew.py
@@ -34,7 +34,7 @@ CONSTRAINT_FILES := ''
 EXTRA_BSV_LIBS:=
 EXTRA_LIBRARIES:=
 RUN_FLAGS:=
-BASE_DIR:={1}
+BSV_TOOLS?={1}
 
 PROJECT_NAME={0}
 
@@ -78,7 +78,7 @@ include $(PWD)/libraries/*/*.mk
 endif
 
 # Do not change: Include base makefile
-include {1}/scripts/rules.mk
+include $(BSV_TOOLS)/scripts/rules.mk
 """
 
 def create_makefile(path, project_name):

--- a/scripts/rules.mk
+++ b/scripts/rules.mk
@@ -10,8 +10,8 @@ OUTFILE?=out
 SRCDIR?=$(PWD)/src
 BSV=bsc
 PWD?=$(shell pwd)
-BSV_TOOLS:=$(BASE_DIR)/scripts/bsvTools.py
-BSV_DEPS:=$(BASE_DIR)/scripts/bsvDeps.py
+BSV_TOOLS_PY:=$(BSV_TOOLS)/scripts/bsvTools.py
+BSV_DEPS:=$(BSV_TOOLS)/scripts/bsvDeps.py
 
 BSV_INCLUDEDIR?=$(PWD)/include
 
@@ -65,11 +65,11 @@ ip_clean:
 
 ip: compile_top ip_clean
 	@echo "Creating IP $(PROJECT_NAME)"
-	$(SILENTCMD)cd $(BUILDDIR); $(BSV_TOOLS) . mkVivado $(PROJECT_NAME) $(TOP_MODULE) --verilog_dir $(VERILOGDIR) $(VERILOGDIR_EXTRAS) $(EXCLUDED_VIVADO) $(VIVADO_ADD_PARAMS) $(VIVADO_INCLUDES) $(CONSTRAINT_FILES)
+	$(SILENTCMD)cd $(BUILDDIR); $(BSV_TOOLS_PY) . mkVivado $(PROJECT_NAME) $(TOP_MODULE) --verilog_dir $(VERILOGDIR) $(VERILOGDIR_EXTRAS) $(EXCLUDED_VIVADO) $(VIVADO_ADD_PARAMS) $(VIVADO_INCLUDES) $(CONSTRAINT_FILES)
 
 up_ip: compile_top
 	@echo "Updating IP $(PROJECT_NAME)"
-	$(SILENTCMD)cd $(BUILDDIR); $(BSV_TOOLS) . upVivado $(PROJECT_NAME) $(TOP_MODULE) $(EXCLUDED_VIVADO) $(VIVADO_ADD_PARAMS)
+	$(SILENTCMD)cd $(BUILDDIR); $(BSV_TOOLS_PY) . upVivado $(PROJECT_NAME) $(TOP_MODULE) $(EXCLUDED_VIVADO) $(VIVADO_ADD_PARAMS)
 
 sim_ip: compile_top
 


### PR DESCRIPTION
By using the bsvNew script, a Makefile with hard-coded path to the BSVTools directory is generated. This approach eliminates the need for an environment variable. As I can see the benefit to lower the entry barrier, this restricts the portability.
This PR keeps this behaviour but allows to overwrite the location with the $BSV_TOOLS environment variable.