### PR TITLE
Build rules: Fix running without zip

### DIFF
--- a/scripts/rules.mk
+++ b/scripts/rules.mk
@@ -8,7 +8,7 @@ endif
 
 ZIP:=""
 ifeq (, $(shell which zip))
-	$(error "No zip in $(PATH), make ip will not generate zip file")
+$(warning "No zip in $(PATH), make ip will not generate zip file")
 else
 	ZIP:=$(shell which zip)
 endif


### PR DESCRIPTION
1. Don't indent with a tab (as make will assume this command belongs to a rule, which it does not)
2. Use warning instead of error (as far as I can tell this is not supposed to be fatal)

Current behavior (without zip):
`/user/local/share/BSVTools/scripts/rules.mk:11: *** recipe commences before first target.  Stop.`
New behavior (without zip):
```
/user/local/share/BSVTools/scripts/rules.mk:11: "No zip in /user/local/share/BSVTools:/opt/tools/bsc/latest/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin, make ip will not generate zip file"
…
```