### PR TITLE
Allow missing .bsv_tools

### DIFF
--- a/bsvNew.py
+++ b/bsvNew.py
@@ -30,7 +30,7 @@ MAIN_MODULE={0}
 TESTBENCH_FILE=src/Testbench.bsv
 
 # Initialize
-include .bsv_tools
+-include .bsv_tools
 ifndef BSV_TOOLS
 $(error BSV_TOOLS is not set (Check .bsv_tools or specify it through the command line))
 endif


### PR DESCRIPTION
As long as BSV_TOOLS is specified instead this should be okay.
See https://www.gnu.org/software/make/manual/html_node/Include.html for the Makefile syntax.