### PR TITLE
Use BSV variable instead of hardcoded 'bsc'

### DIFF
--- a/scripts/rules.mk
+++ b/scripts/rules.mk
@@ -127,7 +127,7 @@ compile: | directories
 
 $(BUILDDIR)/$(OUTFILE): compile
 	@echo Linking $@...
-	$(SILENTCMD)cd $(BUILDDIR); CXXFLAGS="$(CXXFLAGS)" bsc -e $(TESTBENCH_MODULE) -o $(notdir $@) $(BSC_FLAGS) $(BASEPARAMS_SIM) $(addprefix -l , $(EXTRA_LIBRARIES)) $(C_FILES) $(CPP_FILES)
+	$(SILENTCMD)cd $(BUILDDIR); CXXFLAGS="$(CXXFLAGS)" $(BSV) -e $(TESTBENCH_MODULE) -o $(notdir $@) $(BSC_FLAGS) $(BASEPARAMS_SIM) $(addprefix -l , $(EXTRA_LIBRARIES)) $(C_FILES) $(CPP_FILES)
 	@echo Linking finished
 
 sim: $(BUILDDIR)/$(OUTFILE)


### PR DESCRIPTION
Changing the `BSV` variable to another bsc installation I noticed an error running `make`. This was because `bsc` was hardcoded in the `compile` target and was not referring to the other bsc installation defined with `$(BSV)`. This pull request replaces the hardcoded `bsc` with the  `BSV` variable.