### PR TITLE
BSC define improvements

### DIFF
--- a/scripts/rules.mk
+++ b/scripts/rules.mk
@@ -50,6 +50,13 @@ ifndef PARALLEL_SIM_LINK
 PARALLEL_SIM_LINK:=8
 endif
 
+BSC_FLAGS=-cross-info \
+          -parallel-sim-link $(PARALLEL_SIM_LINK) \
+          $(EXTRA_FLAGS)
+
+ifdef VERBOSE
+BSC_FLAGS += -v
+endif
 
 ifeq ($(SIM_TYPE), VERILOG)
 VERILOGDIR=verilog
@@ -58,6 +65,7 @@ BASEPARAMS_SIM=-verilog -vdir $(VERILOGDIR) -vsim modelsim
 COMPILE_FLAGS=-fdir $(PWD) -simdir $(BUILDDIR) -bdir $(BUILDDIR) -info-dir $(BUILDDIR) -p $(LIBRARIES)
 COMPLETE_FLAGS=$(BASEPARAMS) $(COMPILE_FLAGS)
 USED_DIRECTORIES += $(BUILDDIR)/$(VERILOGDIR)
+BSC_FLAGS += -D VERILOG
 
 ifdef VIVADO_ADD_PARAMS
 VIVADO_ADD_PARAMS := --additional $(VIVADO_ADD_PARAMS)
@@ -100,14 +108,6 @@ BASEPARAMS=-sim
 BASEPARAMS_SIM=$(BASEPARAMS)
 COMPILE_FLAGS=-fdir $(PWD) -simdir $(BUILDDIR) -bdir $(BUILDDIR) -info-dir $(BUILDDIR) -p $(LIBRARIES)
 COMPLETE_FLAGS=$(BASEPARAMS) $(COMPILE_FLAGS)
-endif
-
-BSC_FLAGS=-cross-info \
-          -parallel-sim-link $(PARALLEL_SIM_LINK) \
-          $(EXTRA_FLAGS)
-
-ifdef VERBOSE
-BSC_FLAGS += -v
 endif
 
 SRCS=$(wildcard $(SRCDIR)/*.bsv)

--- a/scripts/rules.mk
+++ b/scripts/rules.mk
@@ -100,7 +100,7 @@ up_ip: compile_top
 
 sim_ip: compile_top
 
-compile_top: | directories
+compile_top: $(BUILDDIR)/bsc_defines | directories
 	$(SILENTCMD)$(BSV) -elab -verilog $(COMPLETE_FLAGS) $(BSC_FLAGS) -g $(TOP_MODULE) -u $(SRCDIR)/$(MAIN_MODULE).bsv
 
 else
@@ -120,9 +120,13 @@ $(USED_DIRECTORIES):
 .DEFAULT_GOAL := all
 all: sim
 
+.PHONY: force
+$(BUILDDIR)/bsc_defines: force
+	@echo '$(BSC_FLAGS)' | cmp -s - $@ || (echo '$(BSC_FLAGS)' > $@ ; $(MAKE) clean_project)
+
 directories: $(USED_DIRECTORIES)
 
-compile: | directories
+compile: $(BUILDDIR)/bsc_defines | directories
 	$(SILENTCMD)$(BSV) -elab $(COMPLETE_FLAGS) $(BSC_FLAGS) -g $(TESTBENCH_MODULE) -u $(TESTBENCH_FILE)
 
 $(BUILDDIR)/$(OUTFILE): compile
@@ -139,6 +143,14 @@ clean:
 	$(SILENTCMD)$(RM) -f $(BUILDDIR)/*.bo
 	$(SILENTCMD)$(RM) -f $(BUILDDIR)/*.ba
 	$(SILENTCMD)$(RM) -f $(BUILDDIR)/*.o
+	$(SILENTCMD)$(RM) -f $(BUILDDIR)/$(OUTFILE)
+
+# clean build files except libraries
+BINS=$(addprefix $(BUILDDIR)/,$(notdir $(basename $(SRCS))))
+clean_project:
+	$(SILENTCMD)$(RM) -f $(addsuffix .bo,$(BINS))
+	$(SILENTCMD)$(RM) -f $(addsuffix .ba,$(BINS))
+	$(SILENTCMD)$(RM) -f $(addsuffix .o,$(BINS))
 	$(SILENTCMD)$(RM) -f $(BUILDDIR)/$(OUTFILE)
 
 clean_all: clean


### PR DESCRIPTION
This is a fix to force a rebuild if Bluespec defines in the Makefile are changed. Previous behavior led to inconsistent and unexpected results.

* A new make target `clean_project` only cleans project files and does not touch library files.
* A new define `VERILOG` is set when using this SIM_TYPE. It can be used to include elements not supported by Bluesim.