### PR TITLE
Add an optional flag in bsvNew.py to separate src and test folders

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -45,12 +45,10 @@ This project provides helper scripts that can be used to create Bluespec project
   - Compile and simulate using `bsc` supported Verilog simulators
   - Build IP-XACT Packets for use in Xilinx Vivado
 
-
-
 ### Built With
 
 * Python 3
-* Bluespec Compiler
+* Bluespec Compiler [`bsc`](https://github.com/B-Lang-org/bsc)
 
 
 ## Getting Started
@@ -64,33 +62,37 @@ Have the bluespec compiler and Python 3 installed.
 ### Installation
 
 1. Clone the repo
-```sh
+```bash
 git clone https://github.com/esa-tu-darmstadt/BSVTools.git
 ```
 2. Create a new directory for the Bluespec project
-3. Run `path/to/BSVTools/bsvNew.py PROJECT_NAME`
-4. (Optional) Add libraries to the created library directory (e.g. BlueAXI or BlueLib)
+3. Run the following command to create all necessary files for the Bluespec project. The `--test_dir` is for big projects where it is better to separate testbench from source code.
+```bash
+path/to/BSVTools/bsvNew.py PROJECT_NAME [--test_dir]
+```
+4. (Optional) Add libraries to the created library directory (e.g. [BlueAXI](https://github.com/esa-tu-darmstadt/BlueAXI) or [BlueLib](https://github.com/esa-tu-darmstadt/BlueLib))
 
 The script creates a number of basic Bluespec modules that can be extended as desired.
 
 #### On a second machine
 
-BSVTools stores device specific information in the file `.bsv_tools`. By default this file is excluded from Git using `.gitignore`.
-A new `.bsv_tools` file can be created using:
+BSVTools stores device specific information in the file `.bsv_tools`. By default this file is excluded from Git using `.gitignore`. A new `.bsv_tools` file can be created using:
 
-1. Run `path/to/BSVTools/bsvAdd.py`
+```bash
+path/to/BSVTools/bsvAdd.py
+```
 
 ## Usage
 
 Simulate using Bluesim
 
-```sh
+```bash
 make
 ```
 
 Simulate using Verilog (Modelsim/Questasim by default)
 
-```sh
+```bash
 make SIM_TYPE=VERILOG
 ```
 

--- a/scripts/rules.mk
+++ b/scripts/rules.mk
@@ -32,7 +32,7 @@ EMPTY :=
 SPACE := $(EMPTY) $(EMPTY)
 join-with = $(subst $(SPACE),$1,$(strip $2))
 
-LIBRARIES_BASE = %/Libraries $(SRCDIR) $(EXTRA_BSV_LIBS) $(BSV_INCLUDEDIR)
+LIBRARIES_BASE = %/Libraries $(SRCDIR) $(TEST_DIR) $(EXTRA_BSV_LIBS) $(BSV_INCLUDEDIR)
 LIBRARIES=$(call join-with,:,$(LIBRARIES_BASE))
 
 CXXFLAGS:=$(CXXFLAGS_EXTRA)
@@ -111,7 +111,10 @@ COMPLETE_FLAGS=$(BASEPARAMS) $(COMPILE_FLAGS)
 endif
 
 SRCS=$(wildcard $(SRCDIR)/*.bsv)
-$(shell $(BSV_DEPS) $(SRCDIR) $(BUILDDIR) $(RUN_TEST) > .deps)
+ifdef TEST_DIR
+SRCS+=$(wildcard $(TEST_DIR)/*.bsv)
+endif
+$(shell $(BSV_DEPS) $(SRCDIR) $(TEST_DIR) $(BUILDDIR) $(RUN_TEST) > .deps)
 include .deps
 
 $(USED_DIRECTORIES):


### PR DESCRIPTION
## What does this PR do? 

The file `bsvNew.py` could receive (optional) a flag which is `--test_dir`. If this flag is set, the application would make two folders `src` and `test` to separate testbench files and source code files.

### Why? 

It is useful when the project is large enough to separate source code from testbench and simulations

## Summary of Changes

- Add a variable in `rules.mk` call `TEST_DIR`, which would have the testbench files inside of it. This is used to make the compilation without problem.
-  The new flag `--test_dir` was added to the file `bsvNew.py` and the functions inside of it where updated to make the changes if the flag was set.
- Update `README.md` with the new information and how to use the `--test_dir` flag