### PR TITLE
Add package name to interface of mkTestsMainTest

### DIFF
--- a/bsvNew.py
+++ b/bsvNew.py
@@ -177,7 +177,7 @@ testmain_temp = """package TestsMainTest;
     import {0} :: *;
 
     (* synthesize *)
-    module [Module] mkTestsMainTest(TestHandler);
+    module [Module] mkTestsMainTest(TestHelper::TestHandler);
 
         {0} dut <- mk{0}();
 


### PR DESCRIPTION
Otherwise the bluespec compiler is confused when adding BlueLib to a testbench