### PR TITLE
Generate interfaces for new projects

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -66,7 +66,7 @@ Have the bluespec compiler and Python 3 installed.
 git clone https://github.com/esa-tu-darmstadt/BSVTools.git
 ```
 2. Create a new directory for the Bluespec project
-3. Run the following command to create all necessary files for the Bluespec project. The `--test_dir` is for big projects where it is better to separate testbench from source code.
+3. Run the following command to create all necessary files for the Bluespec project. The `--test_dir` is for big projects where it is better to separate testbench from source code. Optionally specify interfaces which should be added to the Bluespec module with `--interfaces <interface>` (e.g., for a [TaPaSCo](https://github.com/esa-tu-darmstadt/tapasco) PE with memory access use`--interfaces tapasco axi-master`).
 ```bash
 path/to/BSVTools/bsvNew.py PROJECT_NAME [--test_dir]
 ```

--- a/bsvNew.py
+++ b/bsvNew.py
@@ -212,9 +212,12 @@ testmain_temp = """package TestsMainTest;
         Stmt s = {{
             seq
                 $display("Hello World from the testbench.");
+{dut_init}
             endseq
         }};
         FSM testFSM <- mkFSM(s);
+
+{rules}
 
         method Action go();
             testFSM.start();
@@ -251,7 +254,9 @@ def create_base_src(path, project_name, test_dir, intfs):
             name = project_name,
             imports = bsvLineJoin(1, intfs.dut_imports),
             module_inst = bsvLineJoin(2, intfs.dut_instances),
-            connections = bsvLineJoin(2, intfs.dut_connections)
+            connections = bsvLineJoin(2, intfs.dut_connections),
+            dut_init = bsvLineJoin(4, intfs.dut_init),
+            rules = bsvLineJoin(2, intfs.dut_rules),
         ))
 
     with open("{}/{}/TestHelper.bsv".format(path, dir), "w") as f:

--- a/bsvNew.py
+++ b/bsvNew.py
@@ -2,7 +2,7 @@
 
 import argparse, os, sys
 from bsvAdd import create_machine_file
-from scripts.bsvInterfaceBuilder import create_interfaces
+from scripts.bsvInterfaceBuilder import create_interfaces, list_available_interfaces
 
 def dir_path(string):
     if os.path.isdir(string):
@@ -267,7 +267,7 @@ def main():
     parser.add_argument('--path', type=dir_path, default='./')
     parser.add_argument('project_name')
     parser.add_argument('--test_dir', help='Set in case you want to separate in src and test folder', action='store_true')
-    parser.add_argument('--interfaces', help='Add interfaces to the BSV module', nargs='+')
+    parser.add_argument('--interfaces', help='Add interfaces to the BSV module (supported interfaces are "{}")'.format('", "'.join(list_available_interfaces())), nargs='+')
 
     args = None
     try:

--- a/bsvNew.py
+++ b/bsvNew.py
@@ -2,6 +2,7 @@
 
 import argparse, os, sys
 from bsvAdd import create_machine_file
+from scripts.bsvInterfaceBuilder import create_interfaces
 
 def dir_path(string):
     if os.path.isdir(string):
@@ -28,6 +29,20 @@ def create_directories(path, test_dir):
     if test_dir:
         os.mkdir("{}/test".format(path))
     os.mkdir("{}/libraries".format(path))
+
+def create_libraries(path, lib_urls):
+    print("Fetching dependencies...")
+    for lib in lib_urls:
+        os.system("git -C {}/libraries clone {}".format(path, lib))
+
+def bsvLineJoin(indent_count, lines, default = ""):
+    if len(lines) == 0:
+        return default
+    indent = ""
+    for i in range(indent_count):
+        indent += "    "
+    lines = ["{}{}".format(indent, l) for l in lines]
+    return "\n".join(lines)
 
 makefile_temp = """###
 # DO NOT CHANGE
@@ -112,17 +127,26 @@ def create_gitignore(path):
     with open("{}/.gitignore".format(path), "w") as f:
         f.write(gitignore)
 
-top_module_temp = """package {0};
+top_module_temp = """package {name};
 
-interface {0};
-// Add custom interface definitions
+{imports}
+
+interface {name};
+{interface}
 endinterface
 
-module mk{0}({0});
+{typedefs}
+
+module mk{name}({name});
+{module_inst}
 
     rule doNothing;
         $display("Hello World!");
     endrule
+
+{rules}
+
+{interface_connections}
 
 endmodule
 
@@ -174,12 +198,16 @@ endpackage
 testmain_temp = """package TestsMainTest;
     import StmtFSM :: *;
     import TestHelper :: *;
-    import {0} :: *;
+{imports}
+    import {name} :: *;
 
     (* synthesize *)
     module [Module] mkTestsMainTest(TestHelper::TestHandler);
 
-        {0} dut <- mk{0}();
+        {name} dut <- mk{name}();
+{module_inst}
+
+{connections}
 
         Stmt s = {{
             seq
@@ -200,10 +228,18 @@ testmain_temp = """package TestsMainTest;
 endpackage
 """
 
-def create_base_src(path, project_name, test_dir):
+def create_base_src(path, project_name, test_dir, intfs):
     print("Creating main module")
     with open("{}/src/{}.bsv".format(path, project_name), "w") as f:
-        f.write(top_module_temp.format(project_name))
+        f.write(top_module_temp.format(
+            name = project_name,
+            imports = bsvLineJoin(0, intfs.rtl_imports, "// Add imports"),
+            interface = bsvLineJoin(1, intfs.rtl_interface_def, "// Add custom interface definitions"),
+            typedefs = bsvLineJoin(0, intfs.rtl_typedefs),
+            module_inst = bsvLineJoin(1, intfs.rtl_module_inst),
+            rules = bsvLineJoin(1, intfs.rtl_rules),
+            interface_connections = bsvLineJoin(1, intfs.rtl_interface_connections)
+        ))
         
     dir = 'src' if not test_dir else 'test'
 
@@ -211,7 +247,12 @@ def create_base_src(path, project_name, test_dir):
         f.write(testbench_temp)
 
     with open("{}/{}/TestsMainTest.bsv".format(path, dir), "w") as f:
-        f.write(testmain_temp.format(project_name))
+        f.write(testmain_temp.format(
+            name = project_name,
+            imports = bsvLineJoin(1, intfs.dut_imports),
+            module_inst = bsvLineJoin(2, intfs.dut_instances),
+            connections = bsvLineJoin(2, intfs.dut_connections)
+        ))
 
     with open("{}/{}/TestHelper.bsv".format(path, dir), "w") as f:
         f.write(testhelper_temp)
@@ -220,7 +261,8 @@ def main():
     parser = argparse.ArgumentParser(description="Create a new BSV project")
     parser.add_argument('--path', type=dir_path, default='./')
     parser.add_argument('project_name')
-    parser.add_argument('--test_dir', help='Set in case want to separate in src and test folder', action='store_true')
+    parser.add_argument('--test_dir', help='Set in case you want to separate in src and test folder', action='store_true')
+    parser.add_argument('--interfaces', help='Add interfaces to the BSV module', nargs='+')
 
     args = None
     try:
@@ -241,11 +283,14 @@ def main():
         print("Project name needs to NOT have '-' in the name ant NOT be any special keyword. \nPlease chose a different name")
         sys.exit(1)
 
+    intfs = create_interfaces(args.interfaces)
+
     create_directories(args.path, args.test_dir)
+    create_libraries(args.path, intfs.libraries)
     create_machine_file(args.path)
     create_gitignore(args.path)
     create_makefile(args.path, args.project_name, args.test_dir)
-    create_base_src(args.path, args.project_name, args.test_dir)
+    create_base_src(args.path, args.project_name, args.test_dir, intfs)
 
 if __name__ == "__main__":
     main()

--- a/scripts/bsvInterfaceBuilder.py
+++ b/scripts/bsvInterfaceBuilder.py
@@ -240,3 +240,7 @@ available_interfaces = {
     'axi-slave': AXI4MMSlave(),
     'axi-lite-slave': AXI4MMLiteSlave(),
 }
+
+def list_available_interfaces() :
+    aliases = ["axis", "tapasco"]
+    return aliases + list(available_interfaces.keys())

--- a/scripts/bsvInterfaceBuilder.py
+++ b/scripts/bsvInterfaceBuilder.py
@@ -162,6 +162,50 @@ class AXI4MMMaster(Interface):
             "mkConnection(dut.m_wr{name}, s_axi_mem{name}.wr);",
         ]
 
+class AXI4MMLiteMaster(Interface):
+    def __init__(self):
+        super().__init__()
+        self.libraries = [
+            "https://github.com/esa-tu-darmstadt/BlueLib.git",
+            "https://github.com/esa-tu-darmstadt/BlueAXI.git",
+        ]
+        self.rtl_imports = ["BlueAXI"]
+        self.rtl_typedefs = [
+            "typedef 16 AXI_LITE_ADDR_WIDTH;",
+            "typedef 32 AXI_LITE_DATA_WIDTH;",
+        ]
+        self.rtl_interface_def = [
+            "(* prefix=\"M_AXI_LITE{name}\" *) interface AXI4_Lite_Master_Rd_Fab#(AXI_LITE_ADDR_WIDTH, AXI_LITE_DATA_WIDTH) m_lite_rd{name};",
+            "(* prefix=\"M_AXI_LITE{name}\" *) interface AXI4_Lite_Master_Wr_Fab#(AXI_LITE_ADDR_WIDTH, AXI_LITE_DATA_WIDTH) m_lite_wr{name};",
+        ]
+        self.rtl_module_inst = [
+            "let m_lite_rd_inst{name} <- mkAXI4_Lite_Master_Rd(2);",
+            "let m_lite_wr_inst{name} <- mkAXI4_Lite_Master_Wr(2);",
+        ]
+        self.rtl_interface_connections = [
+            "interface m_lite_rd{name} = m_lite_rd_inst{name}.fab;",
+            "interface m_lite_wr{name} = m_lite_wr_inst{name}.fab;",
+        ]
+        self.dut_imports = ["BlueAXI", "Connectable", "GetPut"]
+        self.dut_instances = [
+            "AXI4_Lite_Slave_Wr#(AXI_LITE_ADDR_WIDTH, AXI_LITE_DATA_WIDTH) s_axi_lite_wr{name}<- mkAXI4_Lite_Slave_Wr(16);",
+            "AXI4_Lite_Slave_Rd#(AXI_LITE_ADDR_WIDTH, AXI_LITE_DATA_WIDTH) s_axi_lite_rd{name}<- mkAXI4_Lite_Slave_Rd(16);",
+        ]
+        self.dut_connections = [
+            "mkConnection(dut.m_lite_wr{name}, s_axi_lite_wr{name}.fab);",
+            "mkConnection(dut.m_lite_rd{name}, s_axi_lite_rd{name}.fab);",
+        ]
+        self.dut_rules = [
+            "rule dropAxiLiteWrReqs{name};",
+            "    let r <- s_axi_lite_wr{name}.request.get();",
+            "    s_axi_lite_wr{name}.response.put(AXI4_Lite_Write_Rs_Pkg {{resp: OKAY}});",
+            "endrule",
+            "rule respondAxiLiteRdReqs{name};",
+            "    let r <- s_axi_lite_rd{name}.request.get();",
+            "    s_axi_lite_rd{name}.response.put(AXI4_Lite_Read_Rs_Pkg {{data: 'hcafe, resp: OKAY}});",
+            "endrule",
+        ]
+
 class AXI4MMSlave(Interface):
     def __init__(self):
         super().__init__()
@@ -249,6 +293,7 @@ available_interfaces = {
     'axis-master': AXI4StreamMaster(),
     'axis-slave': AXI4StreamSlave(),
     'axi-master': AXI4MMMaster(),
+    'axi-lite-master': AXI4MMLiteMaster(),
     'axi-slave': AXI4MMSlave(),
     'axi-lite-slave': AXI4MMLiteSlave(),
 }

--- a/scripts/bsvInterfaceBuilder.py
+++ b/scripts/bsvInterfaceBuilder.py
@@ -141,8 +141,8 @@ class AXI4MMMaster(Interface):
             "typedef 0 AXI_USER_WIDTH;",
         ]
         self.rtl_interface_def = [
-            "(* prefix=\"M_AXI\" *) interface AXI4_Master_Rd_Fab#(AXI_ADDR_WIDTH, AXI_DATA_WIDTH, AXI_ID_WIDTH, AXI_USER_WIDTH) m_rd{name};",
-            "(* prefix=\"M_AXI\" *) interface AXI4_Master_Wr_Fab#(AXI_ADDR_WIDTH, AXI_DATA_WIDTH, AXI_ID_WIDTH, AXI_USER_WIDTH) m_wr{name};",
+            "(* prefix=\"M_AXI{name}\" *) interface AXI4_Master_Rd_Fab#(AXI_ADDR_WIDTH, AXI_DATA_WIDTH, AXI_ID_WIDTH, AXI_USER_WIDTH) m_rd{name};",
+            "(* prefix=\"M_AXI{name}\" *) interface AXI4_Master_Wr_Fab#(AXI_ADDR_WIDTH, AXI_DATA_WIDTH, AXI_ID_WIDTH, AXI_USER_WIDTH) m_wr{name};",
         ]
         self.rtl_module_inst = [
             "let m_rd_inst{name} <- mkAXI4_Master_Rd(1, 1, True);",

--- a/scripts/bsvInterfaceBuilder.py
+++ b/scripts/bsvInterfaceBuilder.py
@@ -1,0 +1,224 @@
+def create_interfaces(intf_list):
+    join_intf = Interface()
+    if intf_list == None:
+        return join_intf
+    # resolve aliases
+    intf_list_resolved = []
+    for i in intf_list:
+        if i == "axis":
+            intf_list_resolved.append("axis-master")
+            intf_list_resolved.append("axis-slave")
+        elif i == "tapasco":
+            intf_list_resolved.append("axi-lite-slave")
+            intf_list_resolved.append("interrupt")
+        else:
+            intf_list_resolved.append(i)
+    for intf in intf_list_resolved:
+        if intf not in available_interfaces:
+            raise NameError("Interface '{}' invalid, supported interfaces are 'tapasco axis {}'.".format(intf, " ".join(available_interfaces.keys())))
+        else:
+            intf = available_interfaces[intf]
+            for i in intf.libraries:
+                # avoid duplicates
+                if i not in join_intf.libraries:
+                    join_intf.libraries.append(i)
+            for i in intf.rtl_imports:
+                # avoid duplicates
+                import_str = "import " + i + " :: *;";
+                if import_str not in join_intf.rtl_imports:
+                    join_intf.rtl_imports.append(import_str)
+            for i in intf.rtl_typedefs:
+                # avoid duplicates
+                if i not in join_intf.rtl_typedefs:
+                    join_intf.rtl_typedefs.append(i)
+            for i in intf.rtl_interface_def:
+                join_intf.rtl_interface_def.append(i)
+            for i in intf.rtl_module_inst:
+                join_intf.rtl_module_inst.append(i)
+            for i in intf.rtl_rules:
+                join_intf.rtl_rules.append(i)
+            for i in intf.rtl_interface_connections:
+                join_intf.rtl_interface_connections.append(i)
+            for i in intf.dut_imports:
+                import_str = "import " + i + " :: *;";
+                if import_str not in join_intf.dut_imports:
+                    join_intf.dut_imports.append(import_str)
+            for i in intf.dut_instances:
+                join_intf.dut_instances.append(i)
+            for i in intf.dut_connections:
+                join_intf.dut_connections.append(i)
+    return join_intf
+
+class Interface:
+    def __init__(self):
+        self.libraries = []
+        self.rtl_imports = []
+        self.rtl_typedefs = []
+        self.rtl_interface_def = []
+        self.rtl_module_inst = []
+        self.rtl_rules = []
+        self.rtl_interface_connections = []
+        self.dut_imports = []
+        self.dut_instances = []
+        self.dut_connections = []
+
+class Interrupt(Interface):
+    def __init__(self):
+        super().__init__()
+        self.rtl_imports = ["DReg"]
+        self.rtl_interface_def = ["(* always_ready *) method Bool interrupt();"]
+        self.rtl_module_inst = ["Reg#(Bool) interruptDReg <- mkDReg(False);"]
+        self.rtl_interface_connections = ["method Bool interrupt = interruptDReg;"]
+
+class AXI4StreamMaster(Interface):
+    def __init__(self):
+        super().__init__()
+        self.libraries = [
+            "https://github.com/esa-tu-darmstadt/BlueLib.git",
+            "https://github.com/esa-tu-darmstadt/BlueAXI.git",
+        ]
+        self.rtl_imports = ["BlueAXI"]
+        self.rtl_typedefs = ["typedef 64 AXIS_DATA_WIDTH;"]
+        self.rtl_interface_def = ["interface AXI4_Stream_Wr_Fab#(AXIS_DATA_WIDTH, 0) m_axis;"]
+        self.rtl_module_inst = ["let m_axis_inst <- mkAXI4_Stream_Wr(2);"]
+        self.rtl_interface_connections = ["interface m_axis = m_axis_inst.fab;"]
+        self.dut_imports = ["BlueAXI", "Connectable"]
+        self.dut_instances = ["AXI4_Stream_Rd#(AXIS_DATA_WIDTH, 0) s_axis_inst <- mkAXI4_Stream_Rd(2);"]
+        self.dut_connections = ["mkConnection(dut.m_axis, s_axis_inst.fab);"]
+
+class AXI4StreamSlave(Interface):
+    def __init__(self):
+        super().__init__()
+        self.libraries = [
+            "https://github.com/esa-tu-darmstadt/BlueLib.git",
+            "https://github.com/esa-tu-darmstadt/BlueAXI.git",
+        ]
+        self.rtl_imports = ["BlueAXI"]
+        self.rtl_typedefs = ["typedef 64 AXIS_DATA_WIDTH;"]
+        self.rtl_interface_def = ["interface AXI4_Stream_Rd_Fab#(AXIS_DATA_WIDTH, 0) s_axis;"]
+        self.rtl_module_inst = ["let s_axis_inst <- mkAXI4_Stream_Rd(2);"]
+        self.rtl_interface_connections = ["interface s_axis = s_axis_inst.fab;"]
+        self.dut_imports = ["BlueAXI", "Connectable"]
+        self.dut_instances = ["AXI4_Stream_Wr#(AXIS_DATA_WIDTH, 0) m_axis_inst <- mkAXI4_Stream_Wr(2);"]
+        self.dut_connections = ["mkConnection(m_axis_inst.fab, dut.s_axis);"]
+
+class AXI4MMMaster(Interface):
+    def __init__(self):
+        super().__init__()
+        self.libraries = [
+            "https://github.com/esa-tu-darmstadt/BlueLib.git",
+            "https://github.com/esa-tu-darmstadt/BlueAXI.git",
+        ]
+        self.rtl_imports = ["BlueAXI"]
+        self.rtl_typedefs = [
+            "typedef 64 AXI_ADDR_WIDTH;",
+            "typedef 512 AXI_DATA_WIDTH;",
+            "typedef 8 AXI_ID_WIDTH;",
+            "typedef 0 AXI_USER_WIDTH;",
+        ]
+        self.rtl_interface_def = [
+            "(* prefix=\"M_AXI\" *) interface AXI4_Master_Rd_Fab#(AXI_ADDR_WIDTH, AXI_DATA_WIDTH, AXI_ID_WIDTH, AXI_USER_WIDTH) m_rd;",
+            "(* prefix=\"M_AXI\" *) interface AXI4_Master_Wr_Fab#(AXI_ADDR_WIDTH, AXI_DATA_WIDTH, AXI_ID_WIDTH, AXI_USER_WIDTH) m_wr;",
+        ]
+        self.rtl_module_inst = [
+            "let m_rd_inst <- mkAXI4_Master_Rd(1, 1, True);",
+            "let m_wr_inst <- mkAXI4_Master_Wr(1, 1, 1, True);",
+        ]
+        self.rtl_interface_connections = [
+            "interface m_rd = m_rd_inst.fab;",
+            "interface m_wr = m_wr_inst.fab;",
+        ]
+        self.dut_imports = ["BlueAXI", "Connectable"]
+        self.dut_instances = [
+            "AXI4_Slave_Rd#(AXI_ADDR_WIDTH, AXI_DATA_WIDTH, AXI_ID_WIDTH, AXI_USER_WIDTH) s_axi_rd_inst <- mkAXI4_Slave_Rd(2, 2);",
+            "AXI4_Slave_Wr#(AXI_ADDR_WIDTH, AXI_DATA_WIDTH, AXI_ID_WIDTH, AXI_USER_WIDTH) s_axi_wr_inst <- mkAXI4_Slave_Wr(2, 2, 2);",
+        ]
+        self.dut_connections = [
+            "mkConnection(dut.m_rd, s_axi_rd_inst.fab);",
+            "mkConnection(dut.m_wr, s_axi_wr_inst.fab);",
+        ]
+
+class AXI4MMSlave(Interface):
+    def __init__(self):
+        super().__init__()
+        self.libraries = [
+            "https://github.com/esa-tu-darmstadt/BlueLib.git",
+            "https://github.com/esa-tu-darmstadt/BlueAXI.git",
+        ]
+        self.rtl_imports = ["BlueAXI"]
+        self.rtl_typedefs = [
+            "typedef 64 AXI_ADDR_WIDTH;",
+            "typedef 512 AXI_DATA_WIDTH;",
+            "typedef 8 AXI_ID_WIDTH;",
+            "typedef 0 AXI_USER_WIDTH;",
+        ]
+        self.rtl_interface_def = [
+            "(* prefix=\"S_AXI\" *) interface AXI4_Slave_Rd_Fab#(AXI_ADDR_WIDTH, AXI_DATA_WIDTH, AXI_ID_WIDTH, AXI_USER_WIDTH) s_rd;",
+            "(* prefix=\"S_AXI\" *) interface AXI4_Slave_Wr_Fab#(AXI_ADDR_WIDTH, AXI_DATA_WIDTH, AXI_ID_WIDTH, AXI_USER_WIDTH) s_wr;",
+        ]
+        self.rtl_module_inst = [
+            "let s_rd_inst <- mkAXI4_Slave_Rd(2, 2);",
+            "let s_wr_inst <- mkAXI4_Slave_Wr(2, 2, 2);",
+        ]
+        self.rtl_interface_connections = [
+            "interface s_rd = s_rd_inst.fab;",
+            "interface s_wr = s_wr_inst.fab;",
+        ]
+        self.dut_imports = ["BlueAXI", "Connectable"]
+        self.dut_instances = [
+            "AXI4_Master_Rd#(AXI_ADDR_WIDTH, AXI_DATA_WIDTH, AXI_ID_WIDTH, AXI_USER_WIDTH) m_axi_rd_inst <- mkAXI4_Master_Rd(2, 2, False);",
+            "AXI4_Master_Wr#(AXI_ADDR_WIDTH, AXI_DATA_WIDTH, AXI_ID_WIDTH, AXI_USER_WIDTH) m_axi_wr_inst <- mkAXI4_Master_Wr(2, 2, 2, False);",
+        ]
+        self.dut_connections = [
+            "mkConnection(m_axi_rd_inst.fab, dut.s_rd);",
+            "mkConnection(m_axi_wr_inst.fab, dut.s_wr);",
+        ]
+
+class AXI4MMLiteSlave(Interface):
+    def __init__(self):
+        super().__init__()
+        self.libraries = [
+            "https://github.com/esa-tu-darmstadt/BlueLib.git",
+            "https://github.com/esa-tu-darmstadt/BlueAXI.git",
+        ]
+        self.rtl_imports = ["BlueAXI"]
+        self.rtl_typedefs = [
+            "typedef 12 AXI_SLAVE_ADDR_WIDTH;",
+            "typedef 64 AXI_SLAVE_DATA_WIDTH;",
+        ]
+        self.rtl_interface_def = [
+            "(* prefix=\"S_AXI_LITE\" *) interface AXI4_Lite_Slave_Rd_Fab#(AXI_SLAVE_ADDR_WIDTH, AXI_SLAVE_DATA_WIDTH) s_lite_rd;",
+            "(* prefix=\"S_AXI_LITE\" *) interface AXI4_Lite_Slave_Wr_Fab#(AXI_SLAVE_ADDR_WIDTH, AXI_SLAVE_DATA_WIDTH) s_lite_wr;",
+        ]
+        self.rtl_module_inst = [
+            "Reg#(Bool) start <- mkReg(False);",
+            "Reg#(Bit#(AXI_SLAVE_DATA_WIDTH)) result <- mkReg(0);",
+            "Reg#(Bit#(AXI_SLAVE_DATA_WIDTH)) arg0 <- mkReg(0);",
+            "List#(RegisterOperator#(axiAddrWidth, AXI_SLAVE_DATA_WIDTH)) operators = Nil;",
+            "operators = registerHandler('h00, start, operators);",
+            "operators = registerHandler('h10, result, operators);",
+            "operators = registerHandler('h20, arg0, operators);",
+            "let s_lite_inst <- mkGenericAxi4LiteSlave(operators, 1, 1);",
+        ]
+        self.rtl_interface_connections = [
+            "interface s_lite_rd = s_lite_inst.s_rd;",
+            "interface s_lite_wr = s_lite_inst.s_wr;",
+        ]
+        self.dut_imports = ["BlueAXI", "Connectable"]
+        self.dut_instances = [
+            "AXI4_Lite_Master_Wr#(AXI_SLAVE_ADDR_WIDTH, AXI_SLAVE_DATA_WIDTH) m_axi_lite_wr_inst <- mkAXI4_Lite_Master_Wr(16);",
+            "AXI4_Lite_Master_Rd#(AXI_SLAVE_ADDR_WIDTH, AXI_SLAVE_DATA_WIDTH) m_axi_lite_rd_inst <- mkAXI4_Lite_Master_Rd(16);",
+        ]
+        self.dut_connections = [
+            "mkConnection(m_axi_lite_rd_inst.fab, dut.s_lite_rd);",
+            "mkConnection(m_axi_lite_wr_inst.fab, dut.s_lite_wr);",
+        ]
+
+available_interfaces = {
+    'interrupt': Interrupt(),
+    'axis-master': AXI4StreamMaster(),
+    'axis-slave': AXI4StreamSlave(),
+    'axi-master': AXI4MMMaster(),
+    'axi-slave': AXI4MMSlave(),
+    'axi-lite-slave': AXI4MMLiteSlave(),
+}

--- a/scripts/bsvInterfaceBuilder.py
+++ b/scripts/bsvInterfaceBuilder.py
@@ -13,10 +13,22 @@ def create_interfaces(intf_list):
             intf_list_resolved.append("interrupt")
         else:
             intf_list_resolved.append(i)
+    # build a dict with all name suffixes or empty for a single occurence of the interface
+    intf_names_dict = dict()
+    for intf in intf_list_resolved:
+        count = intf_list_resolved.count(intf)
+        if count == 1:
+            intf_names_dict[intf] = ['']
+        else:
+            names = []
+            for i in range(count):
+                names.append('_{}'.format(i))
+            intf_names_dict[intf] = names
     for intf in intf_list_resolved:
         if intf not in available_interfaces:
             raise NameError("Interface '{}' invalid, supported interfaces are 'tapasco axis {}'.".format(intf, " ".join(available_interfaces.keys())))
         else:
+            intf_name = intf_names_dict[intf].pop(0)
             intf = available_interfaces[intf]
             for i in intf.libraries:
                 # avoid duplicates
@@ -32,25 +44,25 @@ def create_interfaces(intf_list):
                 if i not in join_intf.rtl_typedefs:
                     join_intf.rtl_typedefs.append(i)
             for i in intf.rtl_interface_def:
-                join_intf.rtl_interface_def.append(i)
+                join_intf.rtl_interface_def.append(i.format(name = intf_name))
             for i in intf.rtl_module_inst:
-                join_intf.rtl_module_inst.append(i)
+                join_intf.rtl_module_inst.append(i.format(name = intf_name))
             for i in intf.rtl_rules:
-                join_intf.rtl_rules.append(i)
+                join_intf.rtl_rules.append(i.format(name = intf_name))
             for i in intf.rtl_interface_connections:
-                join_intf.rtl_interface_connections.append(i)
+                join_intf.rtl_interface_connections.append(i.format(name = intf_name))
             for i in intf.dut_imports:
                 import_str = "import " + i + " :: *;";
                 if import_str not in join_intf.dut_imports:
                     join_intf.dut_imports.append(import_str)
             for i in intf.dut_instances:
-                join_intf.dut_instances.append(i)
+                join_intf.dut_instances.append(i.format(name = intf_name))
             for i in intf.dut_connections:
-                join_intf.dut_connections.append(i)
+                join_intf.dut_connections.append(i.format(name = intf_name))
             for i in intf.dut_init:
-                join_intf.dut_init.append(i)
+                join_intf.dut_init.append(i.format(name = intf_name))
             for i in intf.dut_rules:
-                join_intf.dut_rules.append(i)
+                join_intf.dut_rules.append(i.format(name = intf_name))
     return join_intf
 
 class Interface:
@@ -72,12 +84,12 @@ class Interrupt(Interface):
     def __init__(self):
         super().__init__()
         self.rtl_imports = ["DReg"]
-        self.rtl_interface_def = ["(* always_ready *) method Bool interrupt();"]
-        self.rtl_module_inst = ["Reg#(Bool) interruptDReg <- mkDReg(False);"]
-        self.rtl_interface_connections = ["method Bool interrupt = interruptDReg;"]
+        self.rtl_interface_def = ["(* always_ready *) method Bool interrupt{name}();"]
+        self.rtl_module_inst = ["Reg#(Bool) interruptDReg{name} <- mkDReg(False);"]
+        self.rtl_interface_connections = ["method Bool interrupt{name} = interruptDReg{name};"]
         self.dut_rules = [
-            "rule finishOnInterrupt (dut.interrupt);",
-            "    $display(\"Interrupt received, finishing simulation\");",
+            "rule finishOnInterrupt{name} (dut.interrupt{name});",
+            "    $display(\"Interrupt{name} received, finishing simulation\");",
             "    $finish;",
             "endrule",
         ]
@@ -91,12 +103,12 @@ class AXI4StreamMaster(Interface):
         ]
         self.rtl_imports = ["BlueAXI"]
         self.rtl_typedefs = ["typedef 64 AXIS_DATA_WIDTH;"]
-        self.rtl_interface_def = ["interface AXI4_Stream_Wr_Fab#(AXIS_DATA_WIDTH, 0) m_axis;"]
-        self.rtl_module_inst = ["let m_axis_inst <- mkAXI4_Stream_Wr(2);"]
-        self.rtl_interface_connections = ["interface m_axis = m_axis_inst.fab;"]
+        self.rtl_interface_def = ["interface AXI4_Stream_Wr_Fab#(AXIS_DATA_WIDTH, 0) m_axis{name};"]
+        self.rtl_module_inst = ["let m_axis_inst{name} <- mkAXI4_Stream_Wr(2);"]
+        self.rtl_interface_connections = ["interface m_axis{name} = m_axis_inst{name}.fab;"]
         self.dut_imports = ["BlueAXI", "Connectable"]
-        self.dut_instances = ["AXI4_Stream_Rd#(AXIS_DATA_WIDTH, 0) s_axis_inst <- mkAXI4_Stream_Rd(2);"]
-        self.dut_connections = ["mkConnection(dut.m_axis, s_axis_inst.fab);"]
+        self.dut_instances = ["AXI4_Stream_Rd#(AXIS_DATA_WIDTH, 0) s_axis_inst{name} <- mkAXI4_Stream_Rd(2);"]
+        self.dut_connections = ["mkConnection(dut.m_axis{name}, s_axis_inst{name}.fab);"]
 
 class AXI4StreamSlave(Interface):
     def __init__(self):
@@ -107,12 +119,12 @@ class AXI4StreamSlave(Interface):
         ]
         self.rtl_imports = ["BlueAXI"]
         self.rtl_typedefs = ["typedef 64 AXIS_DATA_WIDTH;"]
-        self.rtl_interface_def = ["interface AXI4_Stream_Rd_Fab#(AXIS_DATA_WIDTH, 0) s_axis;"]
-        self.rtl_module_inst = ["let s_axis_inst <- mkAXI4_Stream_Rd(2);"]
-        self.rtl_interface_connections = ["interface s_axis = s_axis_inst.fab;"]
+        self.rtl_interface_def = ["interface AXI4_Stream_Rd_Fab#(AXIS_DATA_WIDTH, 0) s_axis{name};"]
+        self.rtl_module_inst = ["let s_axis_inst{name} <- mkAXI4_Stream_Rd(2);"]
+        self.rtl_interface_connections = ["interface s_axis{name} = s_axis_inst{name}.fab;"]
         self.dut_imports = ["BlueAXI", "Connectable"]
-        self.dut_instances = ["AXI4_Stream_Wr#(AXIS_DATA_WIDTH, 0) m_axis_inst <- mkAXI4_Stream_Wr(2);"]
-        self.dut_connections = ["mkConnection(m_axis_inst.fab, dut.s_axis);"]
+        self.dut_instances = ["AXI4_Stream_Wr#(AXIS_DATA_WIDTH, 0) m_axis_inst{name} <- mkAXI4_Stream_Wr(2);"]
+        self.dut_connections = ["mkConnection(m_axis_inst{name}.fab, dut.s_axis{name});"]
 
 class AXI4MMMaster(Interface):
     def __init__(self):
@@ -129,25 +141,25 @@ class AXI4MMMaster(Interface):
             "typedef 0 AXI_USER_WIDTH;",
         ]
         self.rtl_interface_def = [
-            "(* prefix=\"M_AXI\" *) interface AXI4_Master_Rd_Fab#(AXI_ADDR_WIDTH, AXI_DATA_WIDTH, AXI_ID_WIDTH, AXI_USER_WIDTH) m_rd;",
-            "(* prefix=\"M_AXI\" *) interface AXI4_Master_Wr_Fab#(AXI_ADDR_WIDTH, AXI_DATA_WIDTH, AXI_ID_WIDTH, AXI_USER_WIDTH) m_wr;",
+            "(* prefix=\"M_AXI\" *) interface AXI4_Master_Rd_Fab#(AXI_ADDR_WIDTH, AXI_DATA_WIDTH, AXI_ID_WIDTH, AXI_USER_WIDTH) m_rd{name};",
+            "(* prefix=\"M_AXI\" *) interface AXI4_Master_Wr_Fab#(AXI_ADDR_WIDTH, AXI_DATA_WIDTH, AXI_ID_WIDTH, AXI_USER_WIDTH) m_wr{name};",
         ]
         self.rtl_module_inst = [
-            "let m_rd_inst <- mkAXI4_Master_Rd(1, 1, True);",
-            "let m_wr_inst <- mkAXI4_Master_Wr(1, 1, 1, True);",
+            "let m_rd_inst{name} <- mkAXI4_Master_Rd(1, 1, True);",
+            "let m_wr_inst{name} <- mkAXI4_Master_Wr(1, 1, 1, True);",
         ]
         self.rtl_interface_connections = [
-            "interface m_rd = m_rd_inst.fab;",
-            "interface m_wr = m_wr_inst.fab;",
+            "interface m_rd{name} = m_rd_inst{name}.fab;",
+            "interface m_wr{name} = m_wr_inst{name}.fab;",
         ]
         self.dut_imports = ["BlueAXI", "Connectable", "BRAM"]
         self.dut_instances = [
-            "BRAM2PortBE#(Bit#(63), Bit#(AXI_DATA_WIDTH), TDiv#(AXI_DATA_WIDTH, 8)) bram <- mkBRAM2ServerBE(defaultValue);",
-            "BlueAXIBRAM#(AXI_ADDR_WIDTH, AXI_DATA_WIDTH, AXI_ID_WIDTH) s_axi_mem <- mkBlueAXIBRAM(bram.portA);",
+            "BRAM2PortBE#(Bit#(63), Bit#(AXI_DATA_WIDTH), TDiv#(AXI_DATA_WIDTH, 8)) bram{name} <- mkBRAM2ServerBE(defaultValue);",
+            "BlueAXIBRAM#(AXI_ADDR_WIDTH, AXI_DATA_WIDTH, AXI_ID_WIDTH) s_axi_mem{name} <- mkBlueAXIBRAM(bram{name}.portA);",
         ]
         self.dut_connections = [
-            "mkConnection(dut.m_rd, s_axi_mem.rd);",
-            "mkConnection(dut.m_wr, s_axi_mem.wr);",
+            "mkConnection(dut.m_rd{name}, s_axi_mem{name}.rd);",
+            "mkConnection(dut.m_wr{name}, s_axi_mem{name}.wr);",
         ]
 
 class AXI4MMSlave(Interface):
@@ -165,25 +177,25 @@ class AXI4MMSlave(Interface):
             "typedef 0 AXI_USER_WIDTH;",
         ]
         self.rtl_interface_def = [
-            "(* prefix=\"S_AXI\" *) interface AXI4_Slave_Rd_Fab#(AXI_ADDR_WIDTH, AXI_DATA_WIDTH, AXI_ID_WIDTH, AXI_USER_WIDTH) s_rd;",
-            "(* prefix=\"S_AXI\" *) interface AXI4_Slave_Wr_Fab#(AXI_ADDR_WIDTH, AXI_DATA_WIDTH, AXI_ID_WIDTH, AXI_USER_WIDTH) s_wr;",
+            "(* prefix=\"S_AXI{name}\" *) interface AXI4_Slave_Rd_Fab#(AXI_ADDR_WIDTH, AXI_DATA_WIDTH, AXI_ID_WIDTH, AXI_USER_WIDTH) s_rd{name};",
+            "(* prefix=\"S_AXI{name}\" *) interface AXI4_Slave_Wr_Fab#(AXI_ADDR_WIDTH, AXI_DATA_WIDTH, AXI_ID_WIDTH, AXI_USER_WIDTH) s_wr{name};",
         ]
         self.rtl_module_inst = [
-            "let s_rd_inst <- mkAXI4_Slave_Rd(2, 2);",
-            "let s_wr_inst <- mkAXI4_Slave_Wr(2, 2, 2);",
+            "let s_rd_inst{name} <- mkAXI4_Slave_Rd(2, 2);",
+            "let s_wr_inst{name} <- mkAXI4_Slave_Wr(2, 2, 2);",
         ]
         self.rtl_interface_connections = [
-            "interface s_rd = s_rd_inst.fab;",
-            "interface s_wr = s_wr_inst.fab;",
+            "interface s_rd{name} = s_rd_inst{name}.fab;",
+            "interface s_wr{name} = s_wr_inst{name}.fab;",
         ]
         self.dut_imports = ["BlueAXI", "Connectable"]
         self.dut_instances = [
-            "AXI4_Master_Rd#(AXI_ADDR_WIDTH, AXI_DATA_WIDTH, AXI_ID_WIDTH, AXI_USER_WIDTH) m_axi_rd_inst <- mkAXI4_Master_Rd(2, 2, False);",
-            "AXI4_Master_Wr#(AXI_ADDR_WIDTH, AXI_DATA_WIDTH, AXI_ID_WIDTH, AXI_USER_WIDTH) m_axi_wr_inst <- mkAXI4_Master_Wr(2, 2, 2, False);",
+            "AXI4_Master_Rd#(AXI_ADDR_WIDTH, AXI_DATA_WIDTH, AXI_ID_WIDTH, AXI_USER_WIDTH) m_axi_rd_inst{name} <- mkAXI4_Master_Rd(2, 2, False);",
+            "AXI4_Master_Wr#(AXI_ADDR_WIDTH, AXI_DATA_WIDTH, AXI_ID_WIDTH, AXI_USER_WIDTH) m_axi_wr_inst{name} <- mkAXI4_Master_Wr(2, 2, 2, False);",
         ]
         self.dut_connections = [
-            "mkConnection(m_axi_rd_inst.fab, dut.s_rd);",
-            "mkConnection(m_axi_wr_inst.fab, dut.s_wr);",
+            "mkConnection(m_axi_rd_inst{name}.fab, dut.s_rd{name});",
+            "mkConnection(m_axi_wr_inst{name}.fab, dut.s_wr{name});",
         ]
 
 class AXI4MMLiteSlave(Interface):
@@ -199,38 +211,38 @@ class AXI4MMLiteSlave(Interface):
             "typedef 64 AXI_SLAVE_DATA_WIDTH;",
         ]
         self.rtl_interface_def = [
-            "(* prefix=\"S_AXI_LITE\" *) interface AXI4_Lite_Slave_Rd_Fab#(AXI_SLAVE_ADDR_WIDTH, AXI_SLAVE_DATA_WIDTH) s_lite_rd;",
-            "(* prefix=\"S_AXI_LITE\" *) interface AXI4_Lite_Slave_Wr_Fab#(AXI_SLAVE_ADDR_WIDTH, AXI_SLAVE_DATA_WIDTH) s_lite_wr;",
+            "(* prefix=\"S_AXI_LITE{name}\" *) interface AXI4_Lite_Slave_Rd_Fab#(AXI_SLAVE_ADDR_WIDTH, AXI_SLAVE_DATA_WIDTH) s_lite_rd{name};",
+            "(* prefix=\"S_AXI_LITE{name}\" *) interface AXI4_Lite_Slave_Wr_Fab#(AXI_SLAVE_ADDR_WIDTH, AXI_SLAVE_DATA_WIDTH) s_lite_wr{name};",
         ]
         self.rtl_module_inst = [
-            "Reg#(Bool) start <- mkReg(False);",
-            "Reg#(Bit#(AXI_SLAVE_DATA_WIDTH)) result <- mkReg(0);",
-            "Reg#(Bit#(AXI_SLAVE_DATA_WIDTH)) arg0 <- mkReg(0);",
-            "List#(RegisterOperator#(axiAddrWidth, AXI_SLAVE_DATA_WIDTH)) operators = Nil;",
-            "operators = registerHandler('h00, start, operators);",
-            "operators = registerHandler('h10, result, operators);",
-            "operators = registerHandler('h20, arg0, operators);",
-            "let s_lite_inst <- mkGenericAxi4LiteSlave(operators, 1, 1);",
+            "Reg#(Bool) start{name} <- mkReg(False);",
+            "Reg#(Bit#(AXI_SLAVE_DATA_WIDTH)) result{name} <- mkReg(0);",
+            "Reg#(Bit#(AXI_SLAVE_DATA_WIDTH)) arg0{name} <- mkReg(0);",
+            "List#(RegisterOperator#(axiAddrWidth, AXI_SLAVE_DATA_WIDTH)) operators{name} = Nil;",
+            "operators{name} = registerHandler('h00, start{name}, operators{name});",
+            "operators{name} = registerHandler('h10, result{name}, operators{name});",
+            "operators{name} = registerHandler('h20, arg0{name}, operators{name});",
+            "let s_lite_inst{name} <- mkGenericAxi4LiteSlave(operators{name}, 1, 1);",
         ]
         self.rtl_interface_connections = [
-            "interface s_lite_rd = s_lite_inst.s_rd;",
-            "interface s_lite_wr = s_lite_inst.s_wr;",
+            "interface s_lite_rd{name} = s_lite_inst{name}.s_rd;",
+            "interface s_lite_wr{name} = s_lite_inst{name}.s_wr;",
         ]
         self.dut_imports = ["BlueAXI", "Connectable"]
         self.dut_instances = [
-            "AXI4_Lite_Master_Wr#(AXI_SLAVE_ADDR_WIDTH, AXI_SLAVE_DATA_WIDTH) m_axi_lite_wr_inst <- mkAXI4_Lite_Master_Wr(16);",
-            "AXI4_Lite_Master_Rd#(AXI_SLAVE_ADDR_WIDTH, AXI_SLAVE_DATA_WIDTH) m_axi_lite_rd_inst <- mkAXI4_Lite_Master_Rd(16);",
+            "AXI4_Lite_Master_Wr#(AXI_SLAVE_ADDR_WIDTH, AXI_SLAVE_DATA_WIDTH) m_axi_lite_wr_inst{name} <- mkAXI4_Lite_Master_Wr(16);",
+            "AXI4_Lite_Master_Rd#(AXI_SLAVE_ADDR_WIDTH, AXI_SLAVE_DATA_WIDTH) m_axi_lite_rd_inst{name} <- mkAXI4_Lite_Master_Rd(16);",
         ]
         self.dut_connections = [
-            "mkConnection(m_axi_lite_rd_inst.fab, dut.s_lite_rd);",
-            "mkConnection(m_axi_lite_wr_inst.fab, dut.s_lite_wr);",
+            "mkConnection(m_axi_lite_rd_inst{name}.fab, dut.s_lite_rd{name});",
+            "mkConnection(m_axi_lite_wr_inst{name}.fab, dut.s_lite_wr{name});",
         ]
         self.dut_rules = [
-            "rule dropWrSlaveResp;",
-            "    let r <- axi4_lite_write_response(m_axi_lite_wr_inst);",
+            "rule dropWrSlaveResp{name};",
+            "    let r <- axi4_lite_write_response(m_axi_lite_wr_inst{name});",
             "endrule",
         ]
-        self.dut_init = ["axi4_lite_write(m_axi_lite_wr_inst, 'h00, 1);"]
+        self.dut_init = ["axi4_lite_write(m_axi_lite_wr_inst{name}, 'h00, 1);"]
 
 available_interfaces = {
     'interrupt': Interrupt(),


### PR DESCRIPTION
For many small BSV modules, writing the interface definitions and connecting it to the testbench is quite a lot of copy-paste effort. Therefore I had the idea to add it to the `bsvNew` script. 

The current version is not really advanced (it is actually quite hacky) but fits my intended use-case.