### PR TITLE
Add option for libraries to request rebuild on changed defines

### DIFF
--- a/scripts/rules.mk
+++ b/scripts/rules.mk
@@ -144,6 +144,8 @@ clean:
 
 # clean build files except libraries
 BINS=$(addprefix $(BUILDDIR)/,$(notdir $(basename $(SRCS))))
+# also add libraries which specifically request a rebuild
+BINS+=$(addprefix $(BUILDDIR)/,$(notdir $(basename $(REBUILD_LIBRARIES))))
 clean_project:
 	$(SILENTCMD)$(RM) -f $(addsuffix .bo,$(BINS))
 	$(SILENTCMD)$(RM) -f $(addsuffix .ba,$(BINS))


### PR DESCRIPTION
When Bluespec defines are changed this triggers an automatic rebuild.
As Libraries typically do not rely on defines they are excluded from this rebuild for performance reasons.

This PR adds the option for Libraries to specify when they want to be rebuild in this case (as they relay on defines). This can be defined on a per-file basis:
`REBUILD_LIBRARIES+=Logging`