### PR TITLE
Use bsc_defines to pass compiler flags and use CURDIR instead of PWD

### DIFF
--- a/bsvNew.py
+++ b/bsvNew.py
@@ -99,11 +99,11 @@ CXX_NO_OPT := 1
 # VIVADO_ADD_PARAMS += 'ipx::associate_bus_interfaces -busif M_AXI -clock sconfig_axi_aclk [ipx::current_core]'
 
 # Add custom constraint files, Syntax: Filename,Load Order
-# CONSTRAINT_FILES += "$(PWD)/constraints/custom.xdc,LATE"
+# CONSTRAINT_FILES += "$(CURDIR)/constraints/custom.xdc,LATE"
 
 # Do not change: Load libraries such as BlueAXI or BlueLib
-ifneq ("$(wildcard $(PWD)/libraries/*/*.mk)", "")
-include $(PWD)/libraries/*/*.mk
+ifneq ("$(wildcard $(CURDIR)/libraries/*/*.mk)", "")
+include $(CURDIR)/libraries/*/*.mk
 endif
 
 # Do not change: Include base makefile
@@ -113,7 +113,7 @@ include $(BSV_TOOLS)/scripts/rules.mk
 def create_makefile(path, project_name, test_dir):
     print("Creating makefile")
     dir = 'src' if not test_dir else 'test'
-    test_var = '' if not test_dir else 'TEST_DIR=$(PWD)/test'
+    test_var = '' if not test_dir else 'TEST_DIR=$(CURDIR)/test'
     with open("{}/Makefile".format(path), "w") as f:
         f.write(makefile_temp.format(project_name, dir, test_var))
 

--- a/scripts/rules.mk
+++ b/scripts/rules.mk
@@ -14,9 +14,10 @@ else
 endif
 
 OUTFILE?=out
+PWD?=$(CURDIR)
 SRCDIR?=$(PWD)/src
 BSV=bsc
-PWD?=$(shell pwd)
+
 BSV_TOOLS_PY:=$(BSV_TOOLS)/scripts/bsvTools.py
 BSV_DEPS:=$(BSV_TOOLS)/scripts/bsvDeps.py
 
@@ -95,7 +96,7 @@ ifneq (, $(ZIP))
 endif
 
 compile_top: $(BUILDDIR)/bsc_defines | directories
-	$(SILENTCMD)$(BSV) -elab -verilog $(COMPLETE_FLAGS) $(BSC_FLAGS) -g $(TOP_MODULE) -u $(SRCDIR)/$(MAIN_MODULE).bsv
+	$(SILENTCMD)$(BSV) -elab -verilog $(COMPLETE_FLAGS) $(shell cat $(BUILDDIR)/bsc_defines) -g $(TOP_MODULE) -u $(SRCDIR)/$(MAIN_MODULE).bsv
 
 else
 BASEPARAMS=-sim
@@ -124,7 +125,7 @@ $(BUILDDIR)/bsc_defines: force
 directories: $(USED_DIRECTORIES)
 
 compile: $(BUILDDIR)/bsc_defines | directories
-	$(SILENTCMD)$(BSV) -elab $(COMPLETE_FLAGS) $(BSC_FLAGS) -g $(TESTBENCH_MODULE) -u $(TESTBENCH_FILE)
+	$(SILENTCMD)$(BSV) -elab $(COMPLETE_FLAGS) $(shell cat $(BUILDDIR)/bsc_defines) -g $(TESTBENCH_MODULE) -u $(TESTBENCH_FILE)
 
 $(BUILDDIR)/$(OUTFILE): compile
 	@echo Linking $@...

--- a/scripts/rules.mk
+++ b/scripts/rules.mk
@@ -96,7 +96,7 @@ ifneq (, $(ZIP))
 endif
 
 compile_top: $(BUILDDIR)/bsc_defines | directories
-	$(SILENTCMD)$(BSV) -elab -verilog $(COMPLETE_FLAGS) $(shell cat $(BUILDDIR)/bsc_defines) -g $(TOP_MODULE) -u $(SRCDIR)/$(MAIN_MODULE).bsv
+	$(SILENTCMD)$(BSV) -elab -verilog $(COMPLETE_FLAGS) $(BSC_FLAGS) -g $(TOP_MODULE) -u $(SRCDIR)/$(MAIN_MODULE).bsv
 
 else
 BASEPARAMS=-sim
@@ -120,12 +120,12 @@ all: sim
 
 .PHONY: force
 $(BUILDDIR)/bsc_defines: force
-	@echo '$(BSC_FLAGS)' | cmp -s - $@ || (echo '$(BSC_FLAGS)' > $@ ; $(MAKE) clean_project)
+	@echo '$(shell echo $(BSC_FLAGS) | sed -r "s/'/'\\\''/g")' | cmp -s - $@ || (echo '$(shell echo $(BSC_FLAGS) | sed -r "s/'/'\\\''/g")' > $@ ; $(MAKE) clean_project)
 
 directories: $(USED_DIRECTORIES)
 
 compile: $(BUILDDIR)/bsc_defines | directories
-	$(SILENTCMD)$(BSV) -elab $(COMPLETE_FLAGS) $(shell cat $(BUILDDIR)/bsc_defines) -g $(TESTBENCH_MODULE) -u $(TESTBENCH_FILE)
+	$(SILENTCMD)$(BSV) -elab $(COMPLETE_FLAGS) $(BSC_FLAGS) -g $(TESTBENCH_MODULE) -u $(TESTBENCH_FILE)
 
 $(BUILDDIR)/$(OUTFILE): compile
 	@echo Linking $@...

--- a/scripts/rules.mk
+++ b/scripts/rules.mk
@@ -14,7 +14,7 @@ else
 endif
 
 OUTFILE?=out
-PWD?=$(CURDIR)
+PWD=$(CURDIR)
 SRCDIR?=$(PWD)/src
 BSV=bsc
 


### PR DESCRIPTION
# Motivation
## ``CURDIR`` instead of ``PWD``
When you use a BSVTools project as IP inside another project, you may want to build it using ``make -C my_awesome_bsvtools_project``. ``PWD`` may be inherited by the shell and set only at the first call to make from the command-line. ``CURDIR`` is set after processing ``-C`` flags and really points to the BSVTools project. 

## Using ``bsc_defines`` contents in build commands
As far as I understand, the ``bsc_defines`` file is primarily used to check if any build flags changed and then trigger a rebuild. To obtain the file, the ``BSC_FLAGS`` are echoed into ``bsc_defines``. If you want to pass Bluespec number literals as macros, e.g., for configuration purposes, you have single quotation marks (e.g., ``'h10000``). Echoing BSV macros containing these numbers can break the ``echo`` command for the ``bsc_defines`` file, if not escaped properly. 

However, if the literals are escaped properly, a string consisting of several single quotation marks and backslashes is passed to the ``bsc`` command through ``$(BSC_FLAGS)``, resulting in a parsing error. In order to avoid this issue, we can read the flags from ``bsc_defines``.

Let me know if there is anything that opposes these changes.