### PR TITLE
Remove syntax warning (invalid escape sequence)

### DIFF
--- a/scripts/bsvTools.py
+++ b/scripts/bsvTools.py
@@ -139,7 +139,7 @@ def flattenVerilogIncludes(src, dst):
         dstFilename = dst + '/' + os.path.basename(src)
         with open(dstFilename, "w") as dst_file:
             for l in src_file:
-                m = re.search("^\s*`include \"(.*)\"", l)
+                m = re.search(r'^\s*`include \"(.*)\"', l)
                 if m:
                     dst_file.write("`include \"" + os.path.basename(m.group(1)) + "\"")
                 else:


### PR DESCRIPTION
Use a raw string to prevent Python from misinterpreting backslashes as escape sequences in the regex. For reference:
- https://stackoverflow.com/questions/50504500/deprecationwarning-invalid-escape-sequence-what-to-use-instead-of-d
- https://stackoverflow.com/questions/52335970/how-to-fix-syntaxwarning-invalid-escape-sequence-in-python