### PR TITLE
Allow different simulators apart from modelsim

### DIFF
--- a/scripts/rules.mk
+++ b/scripts/rules.mk
@@ -61,8 +61,9 @@ endif
 
 ifeq ($(SIM_TYPE), VERILOG)
 VERILOGDIR=verilog
-BASEPARAMS=-verilog -vdir $(BUILDDIR)/$(VERILOGDIR) -vsim modelsim
-BASEPARAMS_SIM=-verilog -vdir $(VERILOGDIR) -vsim modelsim
+VSIM?=modelsim
+BASEPARAMS=-verilog -vdir $(BUILDDIR)/$(VERILOGDIR) -vsim $(VSIM)
+BASEPARAMS_SIM=-verilog -vdir $(VERILOGDIR) -vsim $(VSIM)
 COMPILE_FLAGS=-fdir $(PWD) -simdir $(BUILDDIR) -bdir $(BUILDDIR) -info-dir $(BUILDDIR) -p $(LIBRARIES)
 COMPLETE_FLAGS=$(BASEPARAMS) $(COMPILE_FLAGS)
 USED_DIRECTORIES += $(BUILDDIR)/$(VERILOGDIR)


### PR DESCRIPTION
This PR introduces the `VSIM` makefile variable, so that users can set their project verilog simulator to whatever is supported by BSC (e.g., `verilator`).