### PR TITLE
Vivado TCL command

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -102,6 +102,27 @@ Build IP-XACT packet (Needs Vivado in path):
 make SIM_TYPE=VERILOG ip
 ```
 
+Run a custom Vivado Tcl flow on the generated Verilog (Needs Vivado in path), for example:
+
+```sh
+make SIM_TYPE=VERILOG vivado_tcl PART=xcku3p-ffvb676-2-e SCRIPT=$(pwd)/synth.tcl
+```
+
+The `vivado_tcl` target creates a Vivado project in `build/PROJECT_NAME`, copies the generated Verilog sources into
+`build/PROJECT_NAME/src`, and sources the Tcl file given by `SCRIPT`. The sourced script can use the variables
+`project_dir`, `project_name`, `src_path`, and `script_path`.
+
+For example, a small synthesis script could look like this:
+
+```tcl
+read_xdc [file dirname $script_path]/constr.xdc
+synth_design -top mkTop -mode out_of_context
+
+report_timing_summary -file $project_dir/${project_name}_timing.rpt
+report_utilization -file $project_dir/${project_name}_util.rpt
+write_checkpoint -force $project_dir/${project_name}_syn.dcp
+```
+
 _For more examples, please refer to the [Documentation](https://github.com/esa-tu-darmstadt/BSVTools/wiki)_
 
 

--- a/bsvNew.py
+++ b/bsvNew.py
@@ -101,6 +101,10 @@ CXX_NO_OPT := 1
 # Add custom constraint files, Syntax: Filename,Load Order
 # CONSTRAINT_FILES += "$(CURDIR)/constraints/custom.xdc,LATE"
 
+# Custom TCL flow
+# PART ?= xcku3p-ffvb676-2-e
+# SCRIPT ?= $(CURDIR)/synth.tcl
+
 # Do not change: Load libraries such as BlueAXI or BlueLib
 ifneq ("$(wildcard $(CURDIR)/libraries/*/*.mk)", "")
 include $(CURDIR)/libraries/*/*.mk

--- a/bsvNew.py
+++ b/bsvNew.py
@@ -102,8 +102,8 @@ CXX_NO_OPT := 1
 # CONSTRAINT_FILES += "$(CURDIR)/constraints/custom.xdc,LATE"
 
 # Custom TCL flow
-# PART ?= xcku3p-ffvb676-2-e
-# SCRIPT ?= $(CURDIR)/synth.tcl
+# PART := xcku3p-ffvb676-2-e
+# SCRIPT := $(CURDIR)/synth.tcl
 
 # Do not change: Load libraries such as BlueAXI or BlueLib
 ifneq ("$(wildcard $(CURDIR)/libraries/*/*.mk)", "")

--- a/scripts/bsvTools.py
+++ b/scripts/bsvTools.py
@@ -47,11 +47,14 @@ close_project -delete
 puts "VIVADO FINISHED SUCCESSFULLY"
 """
 
-def copyBSVVerilog(src, dest):
+def copyBSVVerilog(src, dest, exclude="", includevivado=True):
     for filename in glob.glob(os.path.join(src, 'Verilog', '*.v')):
-        addLicenseHeader(shutil.copy(filename, dest))
-    for filename in glob.glob(os.path.join(src, 'Verilog.Vivado', '*.v')):
-        addLicenseHeader(shutil.copy(filename, dest))
+        if not os.path.basename(filename) in exclude:
+            addLicenseHeader(shutil.copyfile(filename, os.path.join(dest, os.path.basename(filename))))
+    if includevivado:
+        for filename in glob.glob(os.path.join(src, 'Verilog.Vivado', '*.v')):
+            if not os.path.basename(filename) in exclude:
+                addLicenseHeader(shutil.copyfile(filename, os.path.join(dest, os.path.basename(filename))))
 
 
 def addLicenseHeader(file):
@@ -229,7 +232,62 @@ def mkVivado(cli):
     used = used_fullpath + usedNGC
     removeUnused(used, srcpath)
 
-commands = {'mkVivado':mkVivado}
+def mkVivadoTCL(cli):
+    create_project = """
+set project_dir {project_dir}
+set project_name {project_name}
+set src_path {src_path}
+# optional variables
+set script_path {{{script_path}}}
+
+puts "Creating project $project_name at path $project_dir"
+create_project -part {part} -force $project_name $project_dir
+
+read_verilog [glob -directory $src_path *.v]
+
+puts "Script path: $script_path"
+if {{[file exists $script_path]}} {{
+    source $script_path
+}}
+
+close_project
+exit 0
+"""
+
+    proj_path = os.path.join(os.getcwd(), cli.projectname)
+    src_path = os.path.join(proj_path, "src")
+
+    if not os.path.exists(src_path):
+        os.makedirs(src_path)
+
+    script_path = ""
+    if os.path.exists(cli.script):
+        script_path = cli.script
+
+    copyVerilog(cli.verilog_dir, src_path, cli.exclude)
+    if cli.includes:
+        copyVerilog(cli.includes, src_path, cli.exclude)
+    copyBSVVerilog(cli.bluespec_dir, src_path, ["main.v"])
+
+    if which("vivado") is None:
+        print("Could not find \"vivado\". Make sure Vivado is in the path.")
+        sys.exit(1)
+
+    with open('temp.tcl', "w+") as f:
+        f.write(create_project.format(
+            project_dir=proj_path,
+            project_name=cli.projectname,
+            src_path=src_path,
+            part=cli.part,
+            script_path=script_path
+        ))
+
+    with subprocess.Popen("vivado -mode batch -source temp.tcl -nojournal -nolog", shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, bufsize=1, text=True) as proc:
+        for line in proc.stdout:
+            print(line, end="")
+    os.remove('temp.tcl')
+
+commands = {'mkVivado': mkVivado, 'mkVivadoTCL': mkVivadoTCL}
 
 def find_bluespec():
     pattern = "Bluespec directory: (.*)"
@@ -256,6 +314,10 @@ def main():
     parser.add_argument('--additional', nargs='+', default="", type=str)
     parser.add_argument('--includes', nargs='+', default="", type=str)
     parser.add_argument('--constraints', nargs='+', default="", type=str)
+
+    vivado_tcl = parser.add_argument_group("mkVivadoTCL", description="Options for Vivado TCL project generation")
+    vivado_tcl.add_argument('--part', help="Part number of synthesis target used for project creation", default="xcku3p-ffvb676-2-e", type=str)
+    vivado_tcl.add_argument('--script', help="Custom TCL script sourced from created project", default="", required=False, type=str)
 
     cli = parser.parse_args()
 

--- a/scripts/rules.mk
+++ b/scripts/rules.mk
@@ -99,6 +99,27 @@ endif
 compile_top: $(BUILDDIR)/bsc_defines | directories
 	$(SILENTCMD)$(BSV) -elab -verilog $(COMPLETE_FLAGS) $(BSC_FLAGS) -g $(TOP_MODULE) -u $(SRCDIR)/$(MAIN_MODULE).bsv
 
+ifdef PART
+PART:= --part $(PART)
+endif
+
+ifdef SCRIPT
+SCRIPT:= --script $(SCRIPT)
+endif
+
+vivado_tcl_clean:
+	$(RM) -rf $(BUILDDIR)/$(PROJECT_NAME)
+
+vivado_tcl: compile_top vivado_tcl_clean clean
+	$(SILENTCMD)cd $(BUILDDIR); $(BSV_TOOLS_PY) $(PWD) \
+	mkVivadoTCL $(PROJECT_NAME) \
+				$(TOP_MODULE) \
+				--verilog_dir $(VERILOGDIR) $(VERILOGDIR_EXTRAS) \
+				$(EXCLUDED_VIVADO) \
+				$(VIVADO_INCLUDES) \
+				$(PART) \
+				$(SCRIPT)
+
 else
 BASEPARAMS=-sim
 BASEPARAMS_SIM=$(BASEPARAMS)


### PR DESCRIPTION
This PR adds a `mkVivadoTCL` command and a `vivado_tcl` make target for running custom Vivado Tcl flows on generated Bluespec Verilog.

`make SIM_TYPE=VERILOG vivado_tcl` now:

- runs the existing `compile_top` flow
- copies generated/project Verilog sources into `build/$(PROJECT_NAME)/src`
- creates a Vivado project for `PART`
- sources the user-provided `SCRIPT`

The generated Tcl exposes `project_dir`, `project_name`, `src_path`, and `script_path` to the custom script. Extra Verilog sources can be passed through the existing `VERILOGDIR_EXTRAS` and `VIVADO_INCLUDES` variables. `copyBSVVerilog` now supports excluding files, which is used to skip `main.v` for this flow. New projects get `PART` and `SCRIPT` entries in the generated Makefile.

The command is intended as a project/source setup harness; the custom script can then run anything from out-of-context synthesis to a full implementation and bitstream-generation flow.

Example custom script:

```tcl
read_xdc [file dirname $script_path]/constr.xdc
synth_design -top mkTop -mode out_of_context

opt_design

report_timing_summary -file $project_dir/${project_name}_timing.rpt
report_utilization -file $project_dir/${project_name}_util.rpt
report_drc -file $project_dir/${project_name}_drc.rpt

write_checkpoint -force $project_dir/${project_name}_syn.dcp
```

Example `constr.xdc` for the default BSV clock port:

```tcl
create_clock -period 10.000 -name clk [get_ports CLK]
```
